### PR TITLE
fix rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'rake/testtask'
 
-task default: [:build]
+task default: [:install, :test, :doc]
 
 desc 'Builds and installs'
 task install: [:build] do
@@ -9,7 +9,7 @@ task install: [:build] do
 end
 
 desc 'Runs tests, generates documentation, builds gem (default)'
-task :build => [:test, :doc] do
+task :build do
   sh 'gem build genevalidator.gemspec'
 end
 


### PR DESCRIPTION
This now works... 

Basically, this was what the problem was previously:

`task :build => [:test, :doc] do` runs the following:  (see [Rake docs]())

1. :test (which it can’t run since the gemfile hasn’t yet been built and the dependencies haven't yet been installed)
2. :doc (which it can’t run since the gemfile hasn’t yet been built and the dependencies (yard) haven't been installed)
3. :build

Thus I suggest changing the default task to `[:install, :test, :doc)` 

Ps. If you want to run the tests and produce the docs, it is necessary to install the gemspec and not just build it...

This has been tested on a clean system... :) 