### PR TITLE
Update statsample

### DIFF
--- a/genevalidator.gemspec
+++ b/genevalidator.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('minitest', '~> 5.4')
   s.add_dependency('bio', '~> 1.4')
   s.add_dependency('bio-blastxmlparser', '~>2.0')
-  s.add_dependency('statsample', '1.4') # Updating to 1.5 breaks GV
+  s.add_dependency('statsample', '2.0.1')
 
   s.files         = `git ls-files -z`.split("\x0")
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/lib/genevalidator/ext/array.rb
+++ b/lib/genevalidator/ext/array.rb
@@ -21,7 +21,7 @@ module GeneValidator
     end
 
     def sample_variance
-      m   = mean
+      m   = inject(:+).to_f / size
       sum = inject(0) { |accum, i| accum + (i - m)**2 }
       sum / (length - 1).to_f
     end

--- a/lib/genevalidator/validation_duplication.rb
+++ b/lib/genevalidator/validation_duplication.rb
@@ -24,7 +24,7 @@ module GeneValidator
       @threshold   = threshold
       @result      = validation
       @expected    = expected
-      @average     = averages.mean
+      @average     = averages.inject(:+).to_f / averages.length
       @approach    = 'We expect each BLAST hit to match each region of the' \
                      ' query at most once. Here, we calculate the' \
                      ' distribution of hit coverage against the query' \

--- a/lib/genevalidator/validation_duplication.rb
+++ b/lib/genevalidator/validation_duplication.rb
@@ -251,9 +251,9 @@ module GeneValidator
     # wilcox test implementation from statsample ruby gem
     # many thanks to Claudio for helping us with the implementation!
     def wilcox_test(averages)
-      wilcox = Statsample::Test.wilcoxon_signed_rank(averages.to_scale,
-                                                     Array.new(averages.length,
-                                                               1).to_scale)
+      wilcox = Statsample::Test.wilcoxon_signed_rank(Daru::Vector.new(averages),
+                                                     Daru::Vector.new(Array.new(averages.length,
+                                                               1)))
 
       (averages.length < 15) ? wilcox.probability_exact : wilcox.probability_z
     end

--- a/lib/genevalidator/validation_gene_merge.rb
+++ b/lib/genevalidator/validation_gene_merge.rb
@@ -289,7 +289,7 @@ module GeneValidator
     ##
     # xx and yy are the projections of the 2-d data on the two axes
     def unimodality_test(xx, yy)
-      mean_x = xx.mean
+      mean_x = xx.inject(:+).to_f / xx.length
       median_x = xx.median
       mode_x = xx.mode
       sd_x = xx.standard_deviation
@@ -304,7 +304,7 @@ module GeneValidator
         cond3_x = ((median_x - mode_x).abs / (sd_x + 0.0)) < Math.sqrt(0.3)
       end
 
-      mean_y = yy.mean
+      mean_y = yy.inject(:+).to_f / yy.length
       median_y = yy.median
       mode_y = yy.mode
       sd_y = yy.standard_deviation

--- a/lib/genevalidator/validation_length_rank.rb
+++ b/lib/genevalidator/validation_length_rank.rb
@@ -115,7 +115,7 @@ module GeneValidator
       no_of_hits   = hits_lengths.length
       median       = hits_lengths.median.round
       query_length = prediction.length_protein
-      mean         = hits_lengths.mean.round
+      mean         = (hits_lengths.inject(:+).to_f / hits_lengths.length).round
 
       smallest_hit = hits_lengths[0]
       largest_hit  = hits_lengths[-1]

--- a/test/test_extended_array_methods.rb
+++ b/test/test_extended_array_methods.rb
@@ -8,7 +8,7 @@ module GeneValidator
     describe 'Array Class' do
       it 'test1' do
         v = [1, 2, 3, 4, 5, 6]
-        assert_equal(3.5, v.mean)
+        assert_equal(3.5, v.inject(:+).to_f / v.size)
         assert_equal(3.5, v.median)
         assert_equal(1.870829, v.standard_deviation.round(6))
       end


### PR DESCRIPTION
This necessary because Statsample managed to break GeneValidator once again despite the fact that we were pointing to a specific version of Statsample.