### PR TITLE
Travelling ruby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,14 @@
 *.~*~
 *.gem
 .DS_Store
-Gemfile.lock
 # Gemnasium gem configuration file
 config/gemnasium.yml
 doc
 .yardoc
+tmp
+*-linux-x86/
+*-linux-x86_64/
+*-osx/
+*-linux-x86.tar.gz
+*-linux-x86_64.tar.gz
+*-osx.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 rvm:
-  - "2.1.10"
-  - "2.2.7"
-  - "2.3.4"
+  - "2.2.10"
+  - "2.3.7"
+  - "2.4.4"
+  - "2.5.1"
 before_install:
   - wget -P ~ http://mafft.cbrc.jp/alignment/software/mafft-7.205-with-extensions-src.tgz
   - tar -zxvf ~/mafft-7.205-with-extensions-src.tgz -C ~

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,88 @@
+PATH
+  remote: .
+  specs:
+    genevalidator (1.7.2)
+      bio (~> 1.4)
+      bio-blastxmlparser (~> 2.0)
+      statsample (= 2.1.0)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    awesome_print (1.8.0)
+    backports (3.11.3)
+    bio (1.5.1)
+    bio-blastxmlparser (2.0.4)
+      bio-logger
+      nokogiri
+    bio-logger (1.0.1)
+      log4r (>= 1.1.9)
+    clbustos-rtf (0.4.2)
+    codeclimate-test-reporter (1.0.8)
+      simplecov (<= 0.13)
+    daru (0.1.6)
+      backports
+    dirty-memoize (0.0.4)
+    distribution (0.7.3)
+    docile (1.1.5)
+    extendmatrix (0.4)
+    json (2.1.0)
+    log4r (1.1.10)
+    mini_portile2 (2.3.0)
+    minimization (0.2.3)
+      text-table (~> 1.2)
+    minitest (5.11.3)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    prawn (0.8.4)
+      prawn-core (>= 0.8.4, < 0.9)
+      prawn-layout (>= 0.8.4, < 0.9)
+      prawn-security (>= 0.8.4, < 0.9)
+    prawn-core (0.8.4)
+    prawn-layout (0.8.4)
+    prawn-security (0.8.4)
+    prawn-svg (0.9.1.11)
+      prawn (>= 0.8.4)
+    rake (12.3.1)
+    reportbuilder (1.4.2)
+      clbustos-rtf (~> 0.4.0)
+      prawn (~> 0.8.4)
+      prawn-svg (~> 0.9.1)
+      text-table (~> 1.2)
+    rserve-client (0.3.5)
+    ruby-ole (1.2.12.1)
+    rubyvis (0.6.1)
+    simplecov (0.13.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    spreadsheet (1.1.7)
+      ruby-ole (>= 1.0)
+    statsample (2.1.0)
+      awesome_print (~> 1.6)
+      daru (~> 0.1.6)
+      dirty-memoize (~> 0.0.4)
+      distribution (~> 0.7)
+      extendmatrix (~> 0.4)
+      minimization (~> 0.2)
+      reportbuilder (~> 1.4)
+      rserve-client (~> 0.3)
+      rubyvis (~> 0.6.1)
+      spreadsheet (~> 1.1)
+    text-table (1.2.4)
+    yard (0.9.12)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  codeclimate-test-reporter (~> 1.0.0)
+  genevalidator!
+  minitest (~> 5.10)
+  rake (~> 12.3)
+  simplecov
+  yard (~> 0.9.11)
+
+BUNDLED WITH
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -41,68 +41,33 @@ Each analysis of each query returns a binary result (good vs. potential problem)
 
 
 ## Installation
-### Installation Requirements
-* Ruby (>= 2.1.0)
-* NCBI BLAST+ (>= 2.2.30+) (download [here](http://blast.ncbi.nlm.nih.gov/Blast.cgi?PAGE_TYPE=BlastDocs&DOC_TYPE=Download)).
-* MAFFT installation (>=7.273) (download [here](http://mafft.cbrc.jp/alignment/software/)).
-* A web browser - [Mozilla FireFox](https://www.mozilla.org/en-GB/firefox/new/) & Safari are recommended. At the moment, it is not possible to use Chrome to view the results locally (as chrome does not allow ajax to local files). To avoid this, simply use a different browser (like Firefox or Safari) or start a local server in the results folder.
+See the [Releases](https://github.com/wurmlab/genevalidator/releases) page in order to download the latest version of GeneValidator.
 
-Please see [here](https://gist.github.com/IsmailM/b783e8a06565197084e6) for more help with installing the prerequisites.
+This standalone package includes genevalidator, all of its dependencies (including blast+, mafft and JQ) and the SwissProt BLAST Database.
 
-#### Setting up a BLAST database
-GeneValidator requires a protein BLAST database in order to fully analyse all sequences. The BLAST database needs to be set up with the `-parse_seqids` argument as follows:
+Simply Download and uncompress the appropriate version of GV standalone Package, depending on your system (x86, x86_64, osx):
 
 ```bash
-makeblastdb -in input_db -dbtype prot -parse_seqids
+# Download the GeneValidator Package
+curl -L  -O https://github.com/wurmlab/genevalidator/releases/download/1.7.2/genevalidator-1.7.2-OS_TYPE.tar.gz
+# Uncompress the GeneValidator Package
+tar -zxvf genevalidator-1.7.2-OS_TYPE.tar.gz
 ```
 
-### Installation
-Simply run the following command in the terminal.
+### Setting up a BLAST database
+GeneValidator requires a protein BLAST database in order to fully analyse all sequences. The BLAST database needs to be set up with the `-parse_seqids` argument of the makeblastdb script from BLAST+ (from in Genevalidator Package, in the bin directory).
 
-```bash
-gem install genevalidator
-```
-
-If that doesn't work, try `sudo gem install genevalidator` instead.
-
-##### Running From Source (Not Recommended)
-It is also possible to run from source. However, this is not recommended.
-
-```bash
-# Clone the repository.
-git clone https://github.com/wurmlab/genevalidator.git
-
-# Move into GeneValidator source directory.
-cd GeneValidator
-
-# Install bundler
-gem install bundler
-
-# Use bundler to install dependencies
-bundle install
-
-# Optional: run tests, build documentation and build the gem from source
-bundle exec rake
-
-# Run GeneValidator.
-bundle exec genevalidator -h
-# note that `bundle exec` executes GeneValidator in the context of the bundle
-
-# Alternativaly, install GeneValidator as a gem
-bundle exec rake install
-genevalidator -h
-```
-
-
-
-
-
+See [this page](https://gist.github.com/IsmailM/3e3519de18c5b8b36d8aa0f223fb7948) for more information on how to set up BLAST databases.
 
 ## Usage
-Verify GeneValidator installed by running the following command in the terminal:
+
+GeneValidator can be run immediately after the GeneValidator package has been downloaded and uncompressed.
+
 
 ```bash
-genevalidator
+cd genevalidator-1.7.2-OS-TYPE
+
+./genevalidator -h
 ```
 
 You should see the following output.
@@ -115,8 +80,8 @@ ARGUMENTS:
     Input_File: Path to the input fasta file containing the predicted sequences.
 
 OPTIONAL ARGUMENTS
-    -v, --validations <String>       The Validations to be applied.
-                                     Validation Options Available (separated by coma):
+    -v, --validations <String>     The Validations to be applied.
+                                   Validation Options Available (separated by comma):
                                        all   = All validations (default),
                                        lenc  = Length validation by clusterization,
                                        lenr  = Length validation by ranking,
@@ -125,29 +90,31 @@ OPTIONAL ARGUMENTS
                                        frame = Open reading frame (ORF) validation,
                                        orf   = Main ORF validation,
                                        align = Validating based on multiple alignment
-    -d, --db [BLAST_DATABASE]        Path to the BLAST database
-                                     GeneValidator also supports remote databases:
-                                     e.g.   genevalidator -d "swissprot -remote" Input_File
-    -e, --extract_raw_seqs           Produces a fasta file of the raw sequences of all BLAST hits in the
-                                     supplied BLAST output file. This fasta file can then be provided to
-                                     GeneValidator with the "-r", "--raw_sequences" argument
-    -j, --json_file [JSON_FILE]      Generate HTML report from a JSON file (or a subset of a JSON file)
-                                     produced by GeneValidator
-    -x [BLAST_XML_FILE],             Provide GeneValidator with a pre-computed BLAST XML output
-        --blast_xml_file             file (BLAST -outfmt option 5).
-    -t [BLAST_TABULAR_FILE],         Provide GeneValidator with a pre-computed BLAST tabular output
-        --blast_tabular_file         file. (BLAST -outfmt option 6).
-    -o [BLAST_TABULAR_OPTIONS],      Custom format used in BLAST -outfmt argument
-        --blast_tabular_options      See BLAST+ manual pages for more details
-    -n, --num_threads num_of_threads Specify the number of processor threads to use when running
-                                     BLAST and Mafft within GeneValidator.
-    -r, --raw_sequences [raw_seq]    Supply a fasta file of the raw sequences of all BLAST hits present
-                                     in the supplied BLAST XML or BLAST tabular file.
-    -b, --binaries [binaries]        Path to BLAST and MAFFT bin folders (is added to $PATH variable)
-                                     To be provided as follows:
-                                     e.g.   genevalidator -b /blast/bin/path/ -b /mafft/bin/path/
-        --version                    The version of GeneValidator that you are running.
-    -h, --help                       Show this screen.
+    -d, --db [BLAST_DATABASE]      Path to the BLAST database
+                                   GeneValidator also supports remote databases:
+                                   e.g.genevalidator -d "swissprot -remote" Input_File
+    -e, --extract_raw_seqs         Produces a fasta file of the raw sequences of all
+                                   BLAST hits in the supplied BLAST output file. This
+                                   fasta file can then be provided to
+                                   GeneValidator with the "-r", "--raw_sequences" arg.
+    -j, --json_file [JSON_FILE]    Generate HTML report from a JSON file (or a subset
+                                   of a JSON file) produced by GeneValidator
+    -x [BLAST_XML_FILE],           Provide GeneValidator with a pre-computed BLAST XML
+       --blast_xml_file            output file (BLAST -outfmt option 5).
+    -t [BLAST_TABULAR_FILE],       Provide GeneValidator with a pre-computed BLAST
+       --blast_tabular_file        tabular output file. (BLAST -outfmt option 6).
+    -o [BLAST_TABULAR_OPTIONS],    Custom format used in BLAST -outfmt argument
+        --blast_tabular_options    See BLAST+ manual pages for more details
+    -n, --num_threads [NUM]        Specify the number of processor threads to use when
+                                   running BLAST and Mafft within GeneValidator.
+    -r, --raw_sequences [raw_seq]  Supply a fasta file of the raw sequences of all BLAST
+                                   hits present in the supplied BLAST XML or BLAST
+                                   tabular file.
+    -f, --force_rewrite            Rewrites over existing output.
+    -b, --binaries [binaries]      Path to BLAST and MAFFT bin folders (is added to
+                                   $PATH variable). See docs for more information.
+        --version                  The version of GeneValidator that you are running.
+    -h, --help                     Show this screen.
 ```
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,16 @@
 require 'rake/testtask'
+GEMSPEC = Gem::Specification::load('genevalidator.gemspec')
 
 task default: [:build]
 
 desc 'Builds and installs'
 task install: [:build] do
-  require_relative 'lib/genevalidator/version'
-  sh "gem install ./genevalidator-#{GeneValidator::VERSION}.gem"
+  sh "gem install #{Rake.original_dir}/genevalidator-#{GEMSPEC.version}.gem"
 end
 
 desc 'Runs tests, generates documentation, builds gem (default)'
 task build: [:test, :doc] do
-  sh 'gem build genevalidator.gemspec'
+  sh "gem build #{Rake.original_dir}/genevalidator.gemspec"
 end
 
 desc 'Runs tests'
@@ -26,3 +26,268 @@ desc 'Generates documentation'
 task :doc do
   sh "yardoc 'lib/**/*.rb'"
 end
+
+##
+#### TRAVELLING RUBY
+##
+
+# For Bundler.with_clean_env
+require 'bundler/setup'
+
+APP_NAME = "#{GEMSPEC.name}-#{GEMSPEC.version}"
+PLATFORMS = %w[linux-x86 linux-x86_64 osx]
+TRAVELING_RUBY_VERSION = 'traveling-ruby-20150715-2.2.2'
+TRAVELING_RUBYGEMS_VERSION = 'traveling-ruby-gems-20150715-2.2.2'
+NOKOGIRI_VERSION = 'nokogiri-1.6.6.2'
+MAFFT_LINUX = 'https://mafft.cbrc.jp/alignment/software/mafft-7.397-linux.tgz'
+MAFFT_MAC = 'https://mafft.cbrc.jp/alignment/software/mafft-7.397-mac.zip'
+BLAST_LINUX = 'https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.1//ncbi-blast-2.7.1+-x64-linux.tar.gz'
+BLAST_MAC = 'https://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.7.1//ncbi-blast-2.7.1+-x64-macosx.tar.gz'
+TMP_DIR = "#{Rake.original_dir}/tmp"
+
+desc 'Create standalone GeneValidator packages'
+task :package do
+  rm_rf TMP_DIR
+  mkdir TMP_DIR
+  task('package:build' => ['package:linux-x86', 'package:linux-x86_64', 'package:osx']).invoke
+  rm_rf TMP_DIR
+end
+
+namespace :package do
+  PLATFORMS.each do |platform|
+    task platform => [
+      :bundle_install, :reduce_bundle_size,
+      "#{TMP_DIR}/#{TRAVELING_RUBY_VERSION}-#{platform}.tar.gz",
+      "#{TMP_DIR}/#{TRAVELING_RUBY_VERSION}-#{platform}-#{NOKOGIRI_VERSION}.tar.gz"
+    ] do
+      package_dir   = "#{Rake.original_dir}/#{APP_NAME}-#{platform}"
+      lib_dir       = "#{package_dir}/lib/"
+      exemplar_dir  = "#{package_dir}/exemplar_data/"
+      app_dir       = "#{lib_dir}/app/"
+      vendor_dir    = "#{lib_dir}/vendor/"
+      ruby_dir      = "#{lib_dir}/ruby/"
+      pack_dir      = "#{lib_dir}/packages/"
+      nokogiri_path = "#{TMP_DIR}/#{TRAVELING_RUBY_VERSION}-#{platform}-" \
+                      "#{NOKOGIRI_VERSION}.tar.gz"
+      ruby_path     = "#{TMP_DIR}/#{TRAVELING_RUBY_VERSION}-#{platform}.tar.gz"
+
+      # set up dir structure
+      rm_rf package_dir
+      mkdir_p app_dir
+      mkdir exemplar_dir
+      mkdir ruby_dir
+      mkdir vendor_dir
+      mkdir pack_dir
+
+      cp_r "#{Rake.original_dir}/bin", app_dir
+      cp_r "#{TMP_DIR}/vendor", lib_dir
+
+      cp "#{Rake.original_dir}/data/mrna_data.fasta", exemplar_dir
+      cp "#{Rake.original_dir}/data/protein_data.fasta", exemplar_dir
+
+      cd vendor_dir do
+        File.write('Gemfile', GEMFILE_CONTENTS)
+        mkdir '.bundle'
+        File.write('.bundle/config', BUNDLER_CONFIG)
+
+        sh "tar -xzf #{nokogiri_path} -C ruby"
+      end
+
+      cd lib_dir do
+        sh "tar -xzf #{ruby_path} -C ruby"
+      end
+
+      cd package_dir do
+        File.write(GEMSPEC.name, SCRIPT_CONTENTS)
+        sh "chmod +x #{GEMSPEC.name}"
+      end
+
+      cd pack_dir do
+        process_blast_mafft_packages(platform, lib_dir)
+      end
+
+      unless ENV['DIR_ONLY']
+        cd Rake.original_dir do
+          sh "tar -czf #{APP_NAME}-#{platform}.tar.gz #{APP_NAME}-#{platform}"
+          rm_rf package_dir
+        end
+      end
+    end
+  end
+
+  desc 'Install gems to local directory'
+  task :bundle_install do
+    if RUBY_VERSION !~ /^2\.2\./
+      abort "You can only 'bundle install' using Ruby 2.2, because that's what Traveling Ruby uses."
+    end
+    cd Rake.original_dir do
+
+      cp 'Gemfile', TMP_DIR
+
+      lib_files = Dir['lib/**/**']
+      aux_files = Dir['aux/**/**']
+      file_list = lib_files + aux_files
+      edited_gemspec = []
+      File.readlines('genevalidator.gemspec').each_with_index do |l, index|
+        next if index < 4 # skip first four lines
+        l.chomp!
+        l = "s.version = '#{GEMSPEC.version}'\n" if l =~ /^\s+s.version/
+        l = "s.files = ['#{file_list.join("','")}']" if l =~ /^\s+s.files/
+        l = ["s.add_dependency 'nokogiri', '1.6.6.2'", "end"] if l =~ /^end/
+        edited_gemspec << l
+      end
+      edited_gemspec_content = edited_gemspec.flatten.join("\n")
+      File.write("#{TMP_DIR}/#{GEMSPEC.name}.gemspec", edited_gemspec_content)
+    end
+
+    cd TMP_DIR do
+      Bundler.with_clean_env do
+        sh 'env BUNDLE_IGNORE_CONFIG=1 bundle install --path vendor ' \
+          '--without development test'
+      end
+
+      cd 'vendor/ruby/2.2.0' do
+        cd 'gems' do
+          mkdir APP_NAME
+          %w[aux lib].each { |d| cp_r "#{Rake.original_dir}/#{d}", APP_NAME }
+        end
+
+        cd 'specifications' do
+          cp "#{TMP_DIR}/#{GEMSPEC.name}.gemspec", "#{APP_NAME}.gemspec"
+        end
+      end
+    end
+  end
+
+  desc 'Reduce Vendor size'
+  task :reduce_bundle_size do
+    cd "#{TMP_DIR}/vendor" do
+      sh 'rm -f */*/cache/*'
+      sh 'rm -rf ruby/*/extensions'
+      sh "find ruby/2.2.0/gems -name '*.so' | xargs rm -f"
+      sh "find ruby/2.2.0/gems -name '*.bundle' | xargs rm -f"
+      sh "find ruby/2.2.0/gems -name '*.o' | xargs rm -f"
+
+      # Remove tests
+      %w[test tests spec features benchmark].each do |dir|
+        sh "rm -rf ruby/*/gems/*/#{dir}"
+      end
+
+      # Remove documentation
+      %w[README* CHANGE* Change* COPYING* LICENSE* MIT-LICENSE* TODO *.txt *.md *.rdoc].each do |file|
+        sh "rm -f ruby/*/gems/*/#{file}"
+      end
+      %w[doc docs example examples sample doc-api].each do |dir|
+        sh "rm -rf ruby/*/gems/*/#{dir}"
+      end
+      sh "find ruby -name '*.md' | xargs rm -f"
+
+      # Remove misc unnecessary files
+      sh 'rm -rf ruby/*/gems/*/.gitignore'
+      sh 'rm -rf ruby/*/gems/*/.travis.yml'
+
+      # Remove leftover native extension sources and compilation objects
+      sh 'rm -f ruby/*/gems/*/ext/Makefile'
+      sh 'rm -f ruby/*/gems/*/ext/*/Makefile'
+      sh 'rm -f ruby/*/gems/*/ext/*/tmp'
+      sh "find ruby -name '*.c' | xargs rm -f"
+      sh "find ruby -name '*.cpp' | xargs rm -f"
+      sh "find ruby -name '*.h' | xargs rm -f"
+      sh "find ruby -name '*.rl' | xargs rm -f"
+      sh "find ruby -name 'extconf.rb' | xargs rm -f"
+      sh "find ruby/2.2.0/gems -name '*.o' | xargs rm -f"
+      sh "find ruby/2.2.0/gems -name '*.so' | xargs rm -f"
+      sh "find ruby/2.2.0/gems -name '*.bundle' | xargs rm -f"
+
+      # Remove Java files. They're only used for JRuby support
+      sh "find ruby -name '*.java' | xargs rm -f"
+      sh "find ruby -name '*.class' | xargs rm -f"
+    end
+  end
+end
+
+def process_blast_mafft_packages(platform, lib_dir)
+  case platform
+  when 'osx'
+    download_package(MAFFT_MAC, 'mafft')
+    download_package(BLAST_MAC, 'blast')
+  when 'linux-x86'
+    download_package(MAFFT_LINUX, 'mafft')
+    download_package(BLAST_LINUX, 'blast')
+  when 'linux-x86_64'
+    download_package(MAFFT_LINUX, 'mafft')
+    download_package(BLAST_LINUX, 'blast')
+  end
+end
+
+
+PLATFORMS.each do |platform|
+  file "#{TMP_DIR}/#{TRAVELING_RUBY_VERSION}-#{platform}.tar.gz" do
+    download_runtime(platform)
+  end
+  file "#{TMP_DIR}/#{TRAVELING_RUBY_VERSION}-#{platform}-#{NOKOGIRI_VERSION}.tar.gz" do
+    download_native_extension(platform, NOKOGIRI_VERSION)
+  end
+end
+
+def download_runtime(platform)
+  sh "curl -L --fail -o #{TMP_DIR}/#{TRAVELING_RUBY_VERSION}-#{platform}.tar.gz " +
+    "https://d6r77u77i8pq3.cloudfront.net/releases/#{TRAVELING_RUBY_VERSION}-#{platform}.tar.gz"
+end
+
+def download_native_extension(platform, gem_name_and_version)
+  sh "curl -L --fail -o #{TMP_DIR}/#{TRAVELING_RUBY_VERSION}-#{platform}-#{gem_name_and_version}.tar.gz " +
+    "https://d6r77u77i8pq3.cloudfront.net/releases/#{TRAVELING_RUBYGEMS_VERSION}-#{platform}/#{gem_name_and_version}.tar.gz"
+end
+
+def download_package(url, package_name)
+  if url.end_with?('.tar.gz', '.tgz')
+    mkdir package_name
+    cd package_name do
+      sh "curl -L --fail #{url} | tar -xzf - --strip-components=1"
+    end
+  elsif url.end_with?('.zip')
+    sh "curl -L --fail #{url} -o #{package_name}.zip"
+    sh "unzip #{package_name}.zip"
+    mv 'mafft-mac', package_name
+    rm "#{package_name}.zip"
+  end
+end
+
+GEMFILE_CONTENTS = <<-GEMFILE
+source 'http://rubygems.org'
+
+gem 'bio', '~> 1.4'
+gem 'bio-blastxmlparser', '~> 2.0'
+gem '#{GEMSPEC.name}', '#{GEMSPEC.version}'
+gem 'nokogiri', '1.6.6.2'
+gem 'statsample', '2.1.0'
+GEMFILE
+
+SCRIPT_CONTENTS = <<-SCRIPT
+#!/bin/bash
+set -e
+
+# Figure out where this script is located.
+SELFDIR="`dirname \"$0\"`"
+SELFDIR="`cd \"$SELFDIR\" && pwd`"
+
+# Tell Bundler where the Gemfile and gems are.
+export BUNDLE_GEMFILE="$SELFDIR/lib/vendor/Gemfile"
+unset BUNDLE_IGNORE_CONFIG
+
+MAFFT_DIR=$SELFDIR/lib/packages/mafft/mafftdir
+BLAST_BIN=$SELFDIR/lib/packages/blast/bin
+
+MAFFT_BINARIES="$MAFFT_DIR/libexec"; export MAFFT_BINARIES;
+
+# Run the actual app using the bundled Ruby interpreter, with Bundler activated.
+PATH=$MAFFT_DIR/bin:$BLAST_BIN:$PATH  exec "$SELFDIR/lib/ruby/bin/ruby" -rbundler/setup "$SELFDIR/lib/app/bin/genevalidator" $@
+
+SCRIPT
+
+BUNDLER_CONFIG = <<-CONFIG
+BUNDLE_PATH: .
+BUNDLE_WITHOUT: "development:test"
+BUNDLE_DISABLE_SHARED_GEMS: '1'
+CONFIG

--- a/Rakefile
+++ b/Rakefile
@@ -360,7 +360,7 @@ Please contact us if you require any further information.
 Genevalidator is licensed under the AGPL-3.0 License.
 
 Dependencies packaged with GeneValidator are licensed under their respective licenses:
-BLAST+ (Public Domain), Mafft (BSD), JQ (MIT)
+BLAST+ (Public Domain), Mafft (BSD), JQ (MIT) and SwissProt BLAST DB (CC BY-ND 3.0).
 -------------------------------------------------------------------------------
 
 README

--- a/bin/genevalidator
+++ b/bin/genevalidator
@@ -23,7 +23,7 @@ BANNER
   opt[:validations] = ['all']
   opts.on('-v', '--validations <String>', Array,
           'The Validations to be applied.',
-          'Validation Options Available (separated by coma):',
+          'Validation Options Available (separated by comma):',
           '  all   = All validations (default),',
           '  lenc  = Length validation by clusterization,',
           '  lenr  = Length validation by ranking,',
@@ -76,20 +76,19 @@ BANNER
   end
 
   opt[:num_threads] = 1
-  opts.on('-n', '--num_threads num_of_threads',
+  opts.on('-n', '--num_threads [THREADS]',
           'Specify the number of processor threads to use when running',
           'BLAST and Mafft within GeneValidator.') do |num_threads|
     opt[:num_threads] = num_threads
   end
 
-  opts.on('-r', '--raw_sequences [raw_seq]',
+  opts.on('-r', '--raw_sequences [RAW_SEQ]',
           'Supply a fasta file of the raw sequences of all BLAST hits present',
           'in the supplied BLAST XML or BLAST tabular file.') do |raw_seq|
     opt[:raw_sequences] = raw_seq
   end
 
-  opts.on('-f', '--force_rewrite',
-          'Rewrites over existing output.') do
+  opts.on('-f', '--force_rewrite', 'Rewrites over existing output.') do
     opt[:force_rewrite] = true
   end
 

--- a/genevalidator.gemspec
+++ b/genevalidator.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'genevalidator/version'
 
@@ -18,12 +18,12 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.1.0'
 
   s.add_development_dependency 'minitest', '~> 5.10'
-  s.add_development_dependency 'rake', '~>10.3'
+  s.add_development_dependency 'rake', '~> 12.3'
   s.add_development_dependency 'yard', '~> 0.9.11'
 
   s.add_dependency 'bio', '~> 1.4'
   s.add_dependency 'bio-blastxmlparser', '~>2.0'
-  s.add_dependency 'statsample', '2.0.1'
+  s.add_dependency 'statsample', '2.1.0'
 
   s.files         = `git ls-files -z`.split("\x0")
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Adds Standalone packages (including Travelling Ruby, Mafft and BLAST+).

Have tested on a mac and an x86_64 linux machine and it works perfectly 👍 

They can be found on the [Releases page](https://github.com/wurmlab/genevalidator/releases)

The only thing that users need to do is download and setup a BLAST DB and then they can start using GV. 

What do you think about including a compiled version of SwissProt DB in the package as well? (It is increases the tar filesize  by 100mb)...
