### PR TITLE
stop exiting if seq_type fails

### DIFF
--- a/lib/genevalidator/blast.rb
+++ b/lib/genevalidator/blast.rb
@@ -137,7 +137,7 @@ module GeneValidator
         if remote
           warn '==> BLAST search and subsequent analysis will be done on a remote'
           warn '    database. Please use a local database for larger analysis.'
-        else 
+        else
           warn '==> Running BLAST. This may take a while.'
         end
         warn '' # a blank line

--- a/lib/genevalidator/exceptions.rb
+++ b/lib/genevalidator/exceptions.rb
@@ -3,15 +3,6 @@ module GeneValidator
   class ClasspathError < RuntimeError
   end
 
-  # Exception raised when the command line type argument
-  # does not corrsepond to the type of the sequences in the fasta file
-  class SequenceTypeError < RuntimeError
-    def to_s
-      "\nSequence Type error: Possible cause include that the blast output" \
-      " was not obtained against a protein database.\n"
-    end
-  end
-
   # Exception raised when an unexisting file is accessed
   class FileNotFoundException < RuntimeError
   end

--- a/lib/genevalidator/hsp.rb
+++ b/lib/genevalidator/hsp.rb
@@ -79,9 +79,11 @@ module GeneValidator
     def assert_seq_type(query)
       seq_type = BlastUtils.guess_sequence_type(query)
       raise SequenceTypeError if seq_type != :protein
-    rescue SequenceTypeError => e
-      warn e
-      exit 1
+    rescue SequenceTypeError
+      warn '*** A BLAST Hit failed the sequence-type validation (i.e. the BLAST'
+      warn '    hit sequence seems to be a nucleotide sequence).'
+      warn '    Ensure that the BLAST database used is a protein database.'
+      warn '    Ignoring and continuing with analysis.'
     end
   end
 end

--- a/lib/genevalidator/hsp.rb
+++ b/lib/genevalidator/hsp.rb
@@ -78,12 +78,11 @@ module GeneValidator
 
     def assert_seq_type(query)
       seq_type = BlastUtils.guess_sequence_type(query)
-      raise SequenceTypeError if seq_type != :protein
-    rescue SequenceTypeError
-      warn '*** A BLAST Hit failed the sequence-type validation (i.e. the BLAST'
-      warn '    hit sequence seems to be a nucleotide sequence).'
-      warn '    Ensure that the BLAST database used is a protein database.'
-      warn '    Ignoring and continuing with analysis.'
+      return if seq_type == :protein
+      warn '*** A BLAST hit looks like a nucleotide sequence. Continuing' \
+           ' with the analysis anyway.'
+      warn '    Make sure that you used a protein database or the analysis' \
+           ' results will be incorrect!'
     end
   end
 end


### PR DESCRIPTION
Fixes #140 

Basically we validate each BLAST hit to see if it is a protein sequence using Bioruby (with 90% threshold).

I.e. 
  - we remove all non-letter and ambiguous characters (i.e. N/X) and then check the cleaned sequence. 
  - validation fails if 90% of the BLAST hit sequence is made up of nucleic acid bases [AGCTUagctu].
  - However, the issue is that AGCTU are also amino acids and so if we see a BLAST hit sequence made up of 90% of these amino acids they also fail (I guess this is possible).
  - At the moment, we exit entirely, if any BLAST hit sequence fails the sequence Type Validation.


This PR:
  - Warn user (instead of exiting), when the validation fails and continue as normal

